### PR TITLE
feat: automatically install system deps in run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 ## Prerequisites
 
-``` bash
-sudo apt update && sudo apt upgrade -y
-sudo apt-get install python3
-sudo apt install python3-pip
-sudo apt install python3-pyaudio portaudio19-dev
-sudo apt install python3.11-dev
-sudo apt-get install alsa-tools alsa-utils
-sudo apt-get install flac
-```
+On Linux:
 
-Note that if you are running another version of Python, the python header package (python3.11-dev) will need to match.
+`run.sh` will automatically install the following system dependencies if not already set up on the machine:
+
+- python3-pyaudio
+- portaudio19-dev
+- alsa-tools
+- alsa-utils
+- flac
 
 On MacOS:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "speech"
-version = "0.2.5"
+version = "0.3.0"
 authors = [
   { name="Matt Vella", email="mcvella@gmail.com" },
 ]

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,35 @@
 #!/bin/bash
 cd `dirname $0`
 
+SUDO=sudo
+
+if ! command -v $SUDO; then
+  echo "no sudo on this system, proceeding as current user"
+  SUDO=""
+fi
+
+if command -v apt-get; then
+  if dpkg -l python3-venv; then
+    echo "python3-venv is installed, skipping setup"
+  else
+    if ! apt info python3-venv; then
+      echo "package info not found, trying apt update"
+      $SUDO apt-get -qq update
+    fi
+    $SUDO apt-get install -qqy python3-venv
+  fi
+
+  $SUDO apt-get -qq update
+  $SUDO apt install -qqy python3-pyaudio portaudio19-dev alsa-tools alsa-utils flac
+else
+  echo "Skipping tool installation because your platform is missing apt-get"
+  echo "If you see failures below, install the equivalent of python3-venv for your system"
+fi
+
 if [ -f .installed ]
   then
     source viam-env/bin/activate
   else
-    python3 -m pip install --user virtualenv --break-system-packages
     python3 -m venv viam-env
     source viam-env/bin/activate
     pip3 install --upgrade -r requirements.txt


### PR DESCRIPTION
To make adding the speech module to Linux-based smart machines easier, this PR adds the expected `apt install` command for the required system dependencies. 