### PR TITLE
Fix ALSA device lock

### DIFF
--- a/src/speech/speechio.py
+++ b/src/speech/speechio.py
@@ -636,12 +636,15 @@ class SpeechIOService(SpeechService, EasyResource):
             self.stt = cast(SpeechService, stt)
 
         if not self.disable_audioout:
-            if not mixer.get_init():
-                try:
-                    mixer.init(buffer=1024)
-                except Exception as err:
-                    os.environ["PULSE_SERVER"] = "/run/user/1000/pulse/native"
-                    mixer.init(buffer=1024)
+            # Release mixer before reinitializing
+            if mixer.get_init():
+                mixer.quit()
+                time.sleep(1)
+            try:
+                mixer.init(buffer=1024)
+            except Exception as err:
+                os.environ["PULSE_SERVER"] = "/run/user/1000/pulse/native"
+                mixer.init(buffer=1024)
         else:
             if mixer.get_init():
                 mixer.quit()


### PR DESCRIPTION
This PR resolves an intermittent audio initialization failure where the speech module fails to reinitialize the ALSA audio device during reconfiguration with the error `ALSA: Couldn't open audio device: Invalid argument`. 

The issue occurs because `mixer.get_init()` checks for any active mixer globally, not whether the current instance owns it. During reconfiguration, the existing mixer holds the ALSA device lock, the check returns `True`, initialization is skipped, and the module attempts to use a mixer it never initialized... locking itself out of the audio device.

The fix explicitly releases the mixer before reinitializing during reconfiguration, preventing the self-deadlock. A 1-second sleep allows ALSA time to fully release the device. The existing PulseAudio fallback behavior is preserved.