### PR TITLE
fix: improve config validation, audio init, and mic error handling

### DIFF
--- a/src/speech/speechio.py
+++ b/src/speech/speechio.py
@@ -12,6 +12,7 @@ from typing import (
 )
 from enum import Enum
 from datetime import datetime
+import logging
 import os
 import re
 import asyncio
@@ -99,6 +100,27 @@ class SpeechIOService(SpeechService, EasyResource):
     """
 
     MODEL: ClassVar[Model] = Model.from_string("viam-labs:speech:speechio")
+
+    KNOWN_ATTRIBUTES: ClassVar[frozenset] = frozenset({
+        "speech_provider", "speech_provider_key", "speech_voice",
+        "speech_generation_config",
+        "completion_provider", "completion_model", "completion_provider_org",
+        "completion_provider_key", "completion_persona",
+        "stt_provider", "stt_provider_config",
+        "listen", "listen_phrase_time_limit", "mic_device_name",
+        "listen_trigger_say", "listen_trigger_completion", "listen_trigger_command",
+        "listen_command_buffer_length", "cache_ahead_completions",
+        "disable_mic", "disable_audioout",
+        "use_vosk_vad", "listen_trigger_fuzzy_matching", "listen_trigger_fuzzy_threshold",
+        "save_failed_audio", "use_new_listener", "stt_timeout",
+        "vad_config", "listen_sample_rate",
+    })
+
+    BOOLEAN_ATTRIBUTES: ClassVar[frozenset] = frozenset({
+        "listen", "cache_ahead_completions", "disable_mic", "disable_audioout",
+        "use_vosk_vad", "listen_trigger_fuzzy_matching", "save_failed_audio",
+        "use_new_listener",
+    })
     speech_provider: SpeechProvider
     speech_provider_key: str
     speech_voice: str
@@ -145,8 +167,25 @@ class SpeechIOService(SpeechService, EasyResource):
         Returns:
             Tuple[Sequence[str], Sequence[str]]: A pair of lists of implicit and optional dependencies
         """
+        logger = logging.getLogger(__name__)
         deps = []
         attrs = struct_to_dict(config.attributes)
+
+        unknown = set(attrs.keys()) - cls.KNOWN_ATTRIBUTES
+        if unknown:
+            logger.warning(
+                f"Unknown attribute(s) in speech config (will be ignored): {', '.join(sorted(unknown))}. "
+                f"Check for typos. Known attributes: {', '.join(sorted(cls.KNOWN_ATTRIBUTES))}"
+            )
+
+        for attr_name in cls.BOOLEAN_ATTRIBUTES:
+            val = attrs.get(attr_name)
+            if isinstance(val, str):
+                logger.warning(
+                    f"Attribute '{attr_name}' should be a boolean (true/false), "
+                    f"got string \"{val}\". This may cause unexpected behavior."
+                )
+
         stt_provider = str(attrs.get("stt_provider", ""))
         if stt_provider != "" and "google" not in stt_provider:
             deps.append(stt_provider)

--- a/src/speech/speechio.py
+++ b/src/speech/speechio.py
@@ -1026,9 +1026,16 @@ class SpeechIOService(SpeechService, EasyResource):
             if not mixer.get_init():
                 try:
                     mixer.init(buffer=1024)
-                except Exception as err:
+                except Exception:
                     os.environ["PULSE_SERVER"] = "/run/user/1000/pulse/native"
-                    mixer.init(buffer=1024)
+                    try:
+                        mixer.init(buffer=1024)
+                    except Exception as err:
+                        self.logger.error(
+                            f"Failed to initialize audio output: {err}. "
+                            "Set 'disable_audioout' to true if this machine has no audio device."
+                        )
+                        raise
         else:
             if mixer.get_init():
                 mixer.quit()

--- a/src/speech/speechio.py
+++ b/src/speech/speechio.py
@@ -956,8 +956,18 @@ class SpeechIOService(SpeechService, EasyResource):
             attrs.get("listen_command_buffer_length", 10)
         )
         self.cache_ahead_completions = bool(attrs.get("cache_ahead_completions", False))
-        self.disable_mic = bool(attrs.get("disable_mic", False))
-        self.disable_audioout = bool(attrs.get("disable_audioout", False))
+        raw_disable_mic = attrs.get("disable_mic", False)
+        self.disable_mic = bool(raw_disable_mic)
+        self.logger.info(
+            f"disable_mic: raw={raw_disable_mic!r} (type={type(raw_disable_mic).__name__}), "
+            f"resolved={self.disable_mic}"
+        )
+        raw_disable_audioout = attrs.get("disable_audioout", False)
+        self.disable_audioout = bool(raw_disable_audioout)
+        self.logger.info(
+            f"disable_audioout: raw={raw_disable_audioout!r} (type={type(raw_disable_audioout).__name__}), "
+            f"resolved={self.disable_audioout}"
+        )
         self.use_vosk_vad = bool(
             attrs.get("use_vosk_vad", False)
         )  # New option for Vosk VAD
@@ -1043,6 +1053,7 @@ class SpeechIOService(SpeechService, EasyResource):
         rec_state.rec = sr.Recognizer()
         rec_state.rec.operation_timeout = self.stt_timeout
 
+        self.logger.info(f"Mic setup: disable_mic={self.disable_mic}, skipping={self.disable_mic}")
         if not self.disable_mic:
             # Set up speech recognition
             rec_state.rec.dynamic_energy_threshold = True
@@ -1058,6 +1069,11 @@ class SpeechIOService(SpeechService, EasyResource):
                 rec_state.mic = sr.Microphone(sample_rate=self.listen_sample_rate)
 
             with rec_state.mic as source:
+                if source.stream is None:
+                    raise RuntimeError(
+                        f"Failed to open microphone '{self.mic_device_name or 'default'}'. "
+                        "Check that the device exists and is not in use by another process."
+                    )
                 rec_state.rec.adjust_for_ambient_noise(source, 2)
 
             # set up background listening if desired


### PR DESCRIPTION
## Summary

Improves the speech module's resilience when running on machines without microphones or audio output devices. Adds config validation to catch typos and type mismatches early, handles audio init failures gracefully, and adds debug logging to diagnose `disable_mic` not taking effect on deployed machines.

## Changes

- **Config validation**: Added `KNOWN_ATTRIBUTES` and `BOOLEAN_ATTRIBUTES` sets to `SpeechIOService`. `validate_config` now warns about unrecognized attribute names (e.g. typos like `disableMic` instead of `disable_mic`) and boolean attributes passed as strings (where `bool("false")` would silently evaluate to `True`).
- **Audio output init**: Wrapped the PulseAudio fallback `mixer.init()` in a try/except so that machines with no audio device get a clear error message pointing to `disable_audioout: true` instead of an unhandled ALSA crash.
- **Microphone guard**: Added a defensive check after `Microphone.__enter__` to detect when PyAudio fails to open the audio stream (stream is None) and raise a clear `RuntimeError` instead of letting `speech_recognition`'s `__exit__` crash with `'NoneType' has no attribute 'close'`.
- **Debug logging**: Added `info`-level logs showing the raw config value, Python type, and resolved boolean for `disable_mic` and `disable_audioout` to diagnose why the mic guard may not be taking effect on deployed machines.

## Testing

- Deploy to a machine with `disable_mic: true` and no microphone hardware — verify the module starts without the `NoneType` `__exit__` crash
- Deploy to a machine with no audio device and no `disable_audioout` — verify the error message references `disable_audioout`
- Deploy with a typo in config attributes (e.g. `disableMic`) — verify warning appears in logs
- Check logs for the new `disable_mic: raw=... resolved=...` info lines to confirm config parsing

## Claude Code Prompts Used

- "I am seeing errors on Viam machine with the speech module. It is complaining about a missing microphone, despite disable_mic set to true"
- "Can you check the logs for machine c585ab45 and troubleshoot the error from this module?"
- "let's commit, push, and create a PR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)